### PR TITLE
Add .github

### DIFF
--- a/.github/pull_request_template/dev-merge_template.md
+++ b/.github/pull_request_template/dev-merge_template.md
@@ -1,0 +1,31 @@
+---
+name: "🔨 Merge to Dev Template"
+about: Create a PR for a merge into the dev branch. 
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+:point_right: Read the instructions marked with this emoji to guide use of this template. Before submission, delete all the guidance text.
+
+## Changes Made
+:point_right: A succinct description of the changes made and to which project component.  Delete all guidance text, leaving only the header and the relevant rows in the table below.
+
+| Component | Changes |
+| :-- | :-- |
+| Literature Review | INSERT TEXT HERE|
+| Materials | INSERT TEXT HERE|
+| Data Monitoring | INSERT TEXT HERE|
+| Preprocessing | INSERT TEXT HERE|
+| Other | INSERT TEXT HERE|
+
+## Checklist
+:point_right: Check below to confirm you have taken the following steps before submitting this PR:
+- [ ] All my proposed changes have been pushed to remote.
+- [ ] This pull request is showing as a merge into `dev` (not `main`).
+- [ ] I have assigned a specific reviewer for this pull request.
+- [ ] I have connected any associated issues to this pull request so they will be automatically closed when the PR is merged. (Do not connect an Epic to a pull request for a merge into `dev`.)
+
+## Notes
+:point_right: What additional information should a reviewer know?

--- a/.github/pull_request_template/main-merge_template.md
+++ b/.github/pull_request_template/main-merge_template.md
@@ -1,0 +1,22 @@
+---
+name: 🎁 Merge to Main Template"
+about: Create a PR for a merge into the main branch. 
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+:point_right: Read the instructions marked with this emoji to guide use of this template. Before submission, delete all the guidance text.
+
+## Epic(s) Completed 
+:point_right: A bulleted list of Epics that will be complete with the merge of this pull request.
+
+## Checklist
+:point_right: Check below to confirm you have taken the following steps before submitting this PR:
+- [ ] This pull request is showing as a merge into `main`.
+- [ ] I have assigned a specific reviewer for this pull request.
+- [ ] I have connected any associated Epics to this pull request so they will be automatically closed when the PR is merged.
+
+## Notes
+:point_right: What additional information should a reviewer know?

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,26 @@
+name: Pylint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 notebook
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+       flake8 . --ignore=E


### PR DESCRIPTION
@georgebuzzell @kianooshhosseini In updating pylint requirements across the lab, I noticed that this repo didn't have the .github folder at all.  I have added it on this PR for consistency across lab repos.  It includes the updated flake8 requirements (namely, ignore flake8 requirements), so you should not get error messages when pushing for things like code lines being too long.  Let me know if you have any questions!